### PR TITLE
Update to CentOS 8 with dnf

### DIFF
--- a/projects/centos/Dockerfile
+++ b/projects/centos/Dockerfile
@@ -6,10 +6,8 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
 ARG VERSION=${BASE_IMAGE_VERSION}
 
-RUN yum-config-manager --enable cr && \
-    yum -y --setopt=tsflags=nodocs update && \
-    yum -y clean all && \
-    rm -rf /var/cache/yum
+RUN dnf -y --nodocs upgrade && \
+    dnf clean all
 
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
 

--- a/projects/centos/config.sh
+++ b/projects/centos/config.sh
@@ -4,20 +4,13 @@
 
 # Configure base image dependency
 BASE_IMAGE="centos"
-MAJOR_VERSION="7"
-MINOR_VERSION="6"
-VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.1810"
-BASE_IMAGE_VERSION="${VERSION}"
+BASE_IMAGE_VERSION="8"
 FLOATING_VERSION="latest"
 BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
-BUILD_NUMBER="b6"
-IMAGE_VERSION=("${VERSION}-${BUILD_NUMBER}"
-              "${VERSION}"
-              "${MAJOR_VERSION}"
-              "${MAJOR_VERSION}.${MINOR_VERSION}"
+IMAGE_VERSION=("${BASE_IMAGE_VERSION}"
               "${FLOATING_VERSION}")
 
 # Most specific tag when it is not build locally and in CircleCI
 if [ -n "${CIRCLE_BUILD_NUM}" ]; then
-  IMAGE_VERSION+=("${VERSION}-${BUILD_NUMBER}.${CIRCLE_BUILD_NUM}")
+  IMAGE_VERSION+=("${BASE_IMAGE_VERSION}-b${CIRCLE_BUILD_NUM}")
 fi


### PR DESCRIPTION
Update to CentOS 8, use the CircleCI build number to specifically identify a build artifact. Use dnf instead of yum.