### PR TITLE
issue/4: Use CentOS 8 as base image and set circleci build number

### DIFF
--- a/projects/centos/Dockerfile
+++ b/projects/centos/Dockerfile
@@ -1,24 +1,29 @@
 ARG BASE_IMAGE="centos"
-ARG BASE_IMAGE_VERSION="latest"
+ARG BASE_IMAGE_VERSION="8"
 ARG VERSION=${BASE_IMAGE_VERSION}
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
-ARG VERSION=${BASE_IMAGE_VERSION}
-
-RUN yum-config-manager --enable cr && \
-    yum -y --setopt=tsflags=nodocs update && \
-    yum -y clean all && \
+RUN dnf -y --nodocs update && \
+    dnf clean all && \
     rm -rf /var/cache/yum
 
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG VCS_URL
+ARG VCS_REF
 
-LABEL maintainer="The OpenNMS Group" \
-      license="AGPLv3" \
-      name="CentOS" \
-      version="${VERSION}" \
-      build.date="${BUILD_DATE}" \
-      vendor="OpenNMS Community" \
-      org.opennms.container.image.os.name="CentOS" \
-      org.opennms.container.image.os.version="${VERSION}" \
-      org.opennms.container.image.os.build-date="${BUILD_DATE}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="CentOS ${VERSION}" \
+      org.opencontainers.image.source="${VCS_URL}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}"

--- a/projects/centos/build_container_image.sh
+++ b/projects/centos/build_container_image.sh
@@ -12,7 +12,12 @@ docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
   --build-arg BASE_IMAGE="${BASE_IMAGE}" \
   --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
   --build-arg BUILD_DATE="${BUILD_DATE}" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
   --build-arg VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg VCS_URL="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg VCS_REF="$(git describe --always)" \
   .
 
 docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/centos/config.sh
+++ b/projects/centos/config.sh
@@ -4,20 +4,11 @@
 
 # Configure base image dependency
 BASE_IMAGE="centos"
-MAJOR_VERSION="7"
-MINOR_VERSION="6"
-VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.1810"
-BASE_IMAGE_VERSION="${VERSION}"
-FLOATING_VERSION="latest"
+BASE_IMAGE_VERSION="8"
 BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
-BUILD_NUMBER="b6"
-IMAGE_VERSION=("${VERSION}-${BUILD_NUMBER}"
-              "${VERSION}"
-              "${MAJOR_VERSION}"
-              "${MAJOR_VERSION}.${MINOR_VERSION}"
-              "${FLOATING_VERSION}")
+IMAGE_VERSION=("${BASE_IMAGE_VERSION}")
 
 # Most specific tag when it is not build locally and in CircleCI
 if [ -n "${CIRCLE_BUILD_NUM}" ]; then
-  IMAGE_VERSION+=("${VERSION}-${BUILD_NUMBER}.${CIRCLE_BUILD_NUM}")
+  IMAGE_VERSION+=("${BASE_IMAGE_VERSION}-b${CIRCLE_BUILD_NUM}")
 fi


### PR DESCRIPTION
Use CentOS 8 as base image and set circleci build number as identifier for a specific build artifact.