### PR TITLE
Uprade Maven 3.6.1 to use CentOS 8 based image

### DIFF
--- a/projects/maven-jdk/Dockerfile
+++ b/projects/maven-jdk/Dockerfile
@@ -1,28 +1,39 @@
 ARG BASE_IMAGE=opennms/openjdk
-ARG BASE_IMAGE_VERSION="latest"
+ARG BASE_IMAGE_VERSION="1.8.0.222.b10-11.0.4.11"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
-ARG VERSION="3.6.0"
+ARG VERSION="3.6.1"
 
-ARG MAVEN_URL="https://mirror.netcologne.de/apache.org"
-ARG MAVEN_PKG="${MAVEN_URL}/maven/maven-3/${VERSION}/binaries/apache-maven-${VERSION}-bin.tar.gz"
-ARG MAVEN_HOME="/opt/apache-maven-${VERSION}"
+ARG MAVEN_HOST="https://www-eu.apache.org"
+ARG MAVEN_URL="${MAVEN_HOST}/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+ARG MAVEN_HOME="/opt/apache-maven-${MAVEN_VERSION}"
 
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${MAVEN_HOME}/bin
 
 WORKDIR /opt
 
-RUN curl ${MAVEN_PKG} | tar xz
+RUN curl ${MAVEN_URL} | tar xz
 
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG BUILD_BRANCH
+ARG JDK_VERSION
 
-LABEL maintainer="The OpenNMS Group" \
-      license="Apache License, Version 2.0" \
-      name="Apache Maven" \
-      version="${VERSION}" \
-      build.date="${BUILD_DATE}" \
-      vendor="OpenNMS Community" \
-      org.opennms.container.image.app.maven.name="Apache Maven" \
-      org.opennms.container.image.app.maven.version="${VERSION}" \
-      org.opennms.container.image.app.maven.build-date="${BUILD_DATE}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="Apache Maven ${MAVEN_VERSION} with OpenJDK ${JDK_VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${JDK_VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"

--- a/projects/maven-jdk/build_container_image.sh
+++ b/projects/maven-jdk/build_container_image.sh
@@ -11,11 +11,18 @@ source ../registry-config.sh
 docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
   --build-arg BASE_IMAGE="${BASE_IMAGE}" \
   --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg BUILD_DATE="${BUILD_DATE}" \
   --build-arg VERSION="${VERSION}" \
-  --build-arg BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
+  --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
+  --build-arg MAVEN_VERSION="${MAVEN_VERSION}" \
   --build-arg MAVEN_URL="${MAVEN_URL}" \
-  --build-arg MAVEN_PKG="${MAVEN_PKG}" \
   --build-arg MAVEN_HOME="${MAVEN_HOME}" \
+  --build-arg JDK_VERSION="${JDK_VERSION}" \
   .
 
 docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/maven-jdk/config.sh
+++ b/projects/maven-jdk/config.sh
@@ -7,15 +7,20 @@ CONTAINER_PROJECT="maven"
 
 # Base Image Dependency
 BASE_IMAGE="opennms/openjdk"
-BASE_IMAGE_VERSION="8-11"
+JDK_VERSION="1.8.0.222.b10-11.0.4.11"
+MAVEN_VERSION="3.6.1"
+BASE_IMAGE_VERSION="${JDK_VERSION}-b2552"
 BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
 
 # Version information
-VERSION="3.6.1"
-BUILD_NUMBER="b2"
-IMAGE_VERSION=("${BASE_IMAGE_VERSION}_${VERSION}-${BUILD_NUMBER}"
-               "${VERSION}-${BUILD_NUMBER}")
+VERSION="jdk8-jdk11-${MAVEN_VERSION}"
+IMAGE_VERSION=("${VERSION}")
 
-MAVEN_URL="https://www-eu.apache.org"
-MAVEN_PKG="${MAVEN_URL}/dist/maven/maven-3/${VERSION}/binaries/apache-maven-${VERSION}-bin.tar.gz"
-MAVEN_HOME="/opt/apache-maven-${VERSION}"
+MAVEN_HOST="https://www-eu.apache.org"
+MAVEN_URL="${MAVEN_HOST}/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+MAVEN_HOME="/opt/apache-maven-${MAVEN_VERSION}"
+
+# Most specific tag when it is not build locally and in CircleCI
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${VERSION}-b${CIRCLE_BUILD_NUM}")
+fi

--- a/projects/maven-jdk11/Dockerfile
+++ b/projects/maven-jdk11/Dockerfile
@@ -1,20 +1,21 @@
 ARG BASE_IMAGE=opennms/openjdk
-ARG BASE_IMAGE_VERSION="latest"
+ARG BASE_IMAGE_VERSION="11.0.4.11"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
-ARG VERSION="3.6.0"
-ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG MAVEN_VERSION="3.6.1"
 
-ARG MAVEN_URL="https://mirror.netcologne.de/apache.org"
-ARG MAVEN_PKG="${MAVEN_URL}/maven/maven-3/${VERSION}/binaries/apache-maven-${VERSION}-bin.tar.gz"
-ARG MAVEN_HOME="/opt/apache-maven-${VERSION}"
+ARG MAVEN_HOST="https://www-eu.apache.org"
+ARG MAVEN_URL="${MAVEN_HOST}/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+ARG MAVEN_HOME="/opt/apache-maven-${MAVEN_VERSION}"
 
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${MAVEN_HOME}/bin
 
 WORKDIR /opt
 
-RUN curl ${MAVEN_PKG} | tar xz
+RUN curl ${MAVEN_URL} | tar xz
+
+ARG BUILD_DATE="1970-01-01T00:00:00+0000"
 
 LABEL maintainer="The OpenNMS Group" \
       license="Apache License, Version 2.0" \

--- a/projects/maven-jdk11/Dockerfile
+++ b/projects/maven-jdk11/Dockerfile
@@ -16,13 +16,24 @@ WORKDIR /opt
 RUN curl ${MAVEN_URL} | tar xz
 
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG BUILD_BRANCH
+ARG JDK_VERSION
 
-LABEL maintainer="The OpenNMS Group" \
-      license="Apache License, Version 2.0" \
-      name="Apache Maven" \
-      version="${VERSION}" \
-      build.date="${BUILD_DATE}" \
-      vendor="OpenNMS Community" \
-      org.opennms.container.image.app.maven.name="Apache Maven" \
-      org.opennms.container.image.app.maven.version="${VERSION}" \
-      org.opennms.container.image.app.maven.build-date="${BUILD_DATE}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="Apache Maven ${MAVEN_VERSION} with OpenJDK ${JDK_VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${JDK_VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"

--- a/projects/maven-jdk11/build_container_image.sh
+++ b/projects/maven-jdk11/build_container_image.sh
@@ -11,11 +11,18 @@ source ../registry-config.sh
 docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
   --build-arg BASE_IMAGE="${BASE_IMAGE}" \
   --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg BUILD_DATE="${BUILD_DATE}" \
   --build-arg VERSION="${VERSION}" \
-  --build-arg BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
+  --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
+  --build-arg MAVEN_VERSION="${MAVEN_VERSION}" \
   --build-arg MAVEN_URL="${MAVEN_URL}" \
-  --build-arg MAVEN_PKG="${MAVEN_PKG}" \
   --build-arg MAVEN_HOME="${MAVEN_HOME}" \
+  --build-arg JDK_VERSION="${JDK_VERSION}" \
   .
 
 docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/maven-jdk11/config.sh
+++ b/projects/maven-jdk11/config.sh
@@ -7,17 +7,20 @@ CONTAINER_PROJECT="maven"
 
 # Base Image Dependency
 BASE_IMAGE="opennms/openjdk"
-BASE_IMAGE_VERSION="11.0.3.7-b1"
+JDK_VERSION="11.0.4.11"
+MAVEN_VERSION="3.6.1"
+BASE_IMAGE_VERSION="${JDK_VERSION}-b2553"
 BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
 
 # Version information
-JDK_VERSION="jdk11"
-VERSION="3.6.1"
-BUILD_NUMBER="b1"
-IMAGE_VERSION=("${JDK_VERSION}_${VERSION}-${BUILD_NUMBER}"
-               "${JDK_VERSION}_${VERSION}")
+VERSION="jdk11-${MAVEN_VERSION}"
+IMAGE_VERSION=("${VERSION}")
 
-MAVEN_URL="https://www-eu.apache.org"
-MAVEN_PKG="${MAVEN_URL}/dist/maven/maven-3/${VERSION}/binaries/apache-maven-${VERSION}-bin.tar.gz"
-MAVEN_HOME="/opt/apache-maven-${VERSION}"
+MAVEN_HOST="https://www-eu.apache.org"
+MAVEN_URL="${MAVEN_HOST}/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+MAVEN_HOME="/opt/apache-maven-${MAVEN_VERSION}"
 
+# Most specific tag when it is not build locally and in CircleCI
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${VERSION}-b${CIRCLE_BUILD_NUM}")
+fi

--- a/projects/maven-jdk8/Dockerfile
+++ b/projects/maven-jdk8/Dockerfile
@@ -3,25 +3,37 @@ ARG BASE_IMAGE_VERSION="latest"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
-ARG VERSION="3.6.0"
-ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG VERSION="3.6.1"
 
-ARG MAVEN_URL="https://mirror.netcologne.de/apache.org"
-ARG MAVEN_PKG="${MAVEN_URL}/maven/maven-3/${VERSION}/binaries/apache-maven-${VERSION}-bin.tar.gz"
-ARG MAVEN_HOME="/opt/apache-maven-${VERSION}"
+ARG MAVEN_HOST="https://www-eu.apache.org"
+ARG MAVEN_URL="${MAVEN_HOST}/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+ARG MAVEN_HOME="/opt/apache-maven-${MAVEN_VERSION}"
 
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${MAVEN_HOME}/bin
 
 WORKDIR /opt
 
-RUN curl ${MAVEN_PKG} | tar xz
+RUN curl ${MAVEN_URL} | tar xz
 
-LABEL maintainer="The OpenNMS Group" \
-      license="Apache License, Version 2.0" \
-      name="Apache Maven" \
-      version="${VERSION}" \
-      build.date="${BUILD_DATE}" \
-      vendor="OpenNMS Community" \
-      org.opennms.container.image.app.maven.name="Apache Maven" \
-      org.opennms.container.image.app.maven.version="${VERSION}" \
-      org.opennms.container.image.app.maven.build-date="${BUILD_DATE}"
+ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG BUILD_BRANCH
+ARG JDK_VERSION
+
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="Apache Maven ${MAVEN_VERSION} with OpenJDK ${JDK_VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${JDK_VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"

--- a/projects/maven-jdk8/build_container_image.sh
+++ b/projects/maven-jdk8/build_container_image.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-# shellcheck source=projects/maven-jdk8/config.sh
+# shellcheck source=projects/maven-jdk11/config.sh
 source ./config.sh
 
 # shellcheck source=projects/registry-config.sh
@@ -11,11 +11,18 @@ source ../registry-config.sh
 docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
   --build-arg BASE_IMAGE="${BASE_IMAGE}" \
   --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg BUILD_DATE="${BUILD_DATE}" \
   --build-arg VERSION="${VERSION}" \
-  --build-arg BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
+  --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
+  --build-arg MAVEN_VERSION="${MAVEN_VERSION}" \
   --build-arg MAVEN_URL="${MAVEN_URL}" \
-  --build-arg MAVEN_PKG="${MAVEN_PKG}" \
   --build-arg MAVEN_HOME="${MAVEN_HOME}" \
+  --build-arg JDK_VERSION="${JDK_VERSION}" \
   .
 
 docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/maven-jdk8/config.sh
+++ b/projects/maven-jdk8/config.sh
@@ -2,25 +2,25 @@
 
 # shellcheck disable=SC2034
 
-
 # Overwrite project name on DockerHub
 CONTAINER_PROJECT="maven"
 
 # Base Image Dependency
 BASE_IMAGE="opennms/openjdk"
-BASE_IMAGE_VERSION="1.8.0.212.b04-b1"
+JDK_VERSION="1.8.0.222.b10"
+MAVEN_VERSION="3.6.1"
+BASE_IMAGE_VERSION="${JDK_VERSION}-b2551"
 BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
 
 # Version information
-JDK_VERSION="jdk8"
-VERSION="3.6.1"
-BUILD_NUMBER="b1"
-IMAGE_VERSION=("${JDK_VERSION}_${VERSION}-${BUILD_NUMBER}"
-               "${JDK_VERSION}_${VERSION}"
-               "${VERSION}-${BUILD_NUMBER}"
-               "${VERSION}")
+VERSION="jdk8-${MAVEN_VERSION}"
+IMAGE_VERSION=("${VERSION}")
 
-MAVEN_URL="https://www-eu.apache.org"
-MAVEN_PKG="${MAVEN_URL}/dist/maven/maven-3/${VERSION}/binaries/apache-maven-${VERSION}-bin.tar.gz"
-MAVEN_HOME="/opt/apache-maven-${VERSION}"
+MAVEN_HOST="https://www-eu.apache.org"
+MAVEN_URL="${MAVEN_HOST}/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+MAVEN_HOME="/opt/apache-maven-${MAVEN_VERSION}"
 
+# Most specific tag when it is not build locally and in CircleCI
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${VERSION}-b${CIRCLE_BUILD_NUM}")
+fi


### PR DESCRIPTION
Upgrade Maven images for JDK 8, JDK 11 and with both JDKs to CentOS 8.