### PR TITLE
Create a Debian base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,10 @@ jobs:
   tomcat:
     <<: *common_environment
     working_directory: ~/opennms-container/projects/tomcat
+
+  debian:
+    <<: *common_environment
+    working_directory: ~/opennms-container/projects/debian
   
 workflows:
   version: 2
@@ -200,3 +204,6 @@ workflows:
           requires:
             - shellcheck
             - maven-jdk
+      - debian:
+          requires:
+            - shellcheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .project
 .DS_Store
+.*.sw?
 *.iml
 *.oci
 

--- a/projects/debian/.dockerignore
+++ b/projects/debian/.dockerignore
@@ -1,0 +1,10 @@
+.circleci
+.git
+.idea
+images
+*.md
+*.adoc
+*.env
+*.iml
+.gitignore
+LICENSE

--- a/projects/debian/Dockerfile
+++ b/projects/debian/Dockerfile
@@ -1,0 +1,37 @@
+ARG BASE_IMAGE="debian"
+ARG BASE_IMAGE_VERSION="jessie-slim"
+ARG VERSION=${BASE_IMAGE_VERSION}
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
+
+ARG VERSION=${BASE_IMAGE_VERSION}
+
+ARG PACKAGES="software-properties-common"
+
+RUN apt-get update && \
+	apt-get -u -y dist-upgrade
+
+RUN apt-get -y install ${PACKAGES}
+
+ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG BUILD_BRANCH
+
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="CentOS ${VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"
+

--- a/projects/debian/Dockerfile
+++ b/projects/debian/Dockerfile
@@ -9,9 +9,10 @@ ARG VERSION=${BASE_IMAGE_VERSION}
 ARG PACKAGES="software-properties-common"
 
 RUN apt-get update && \
-	apt-get -u -y dist-upgrade
-
-RUN apt-get -y install ${PACKAGES}
+    apt-get -u -y dist-upgrade && \
+    apt-get -y --no-install-recommends install ${PACKAGES} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
 ARG SOURCE

--- a/projects/debian/build_container_image.sh
+++ b/projects/debian/build_container_image.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+set -x
+
+# shellcheck source=projects/centos/config.sh
+source ./config.sh
+
+# shellcheck source=projects/registry-config.sh
+source ../registry-config.sh
+
+docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg BUILD_DATE="${BUILD_DATE}" \
+  --build-arg VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
+  --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
+  .
+
+docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/debian/config.sh
+++ b/projects/debian/config.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC2034
+
+# Configure base image dependency
+BASE_IMAGE="debian"
+VERSION="jessie"
+BASE_IMAGE_VERSION="${VERSION}"
+BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
+IMAGE_VERSION=("${VERSION}")
+
+# Most specific tag when it is not build locally and in CircleCI
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${VERSION}-b${CIRCLE_BUILD_NUM}")
+fi
+

--- a/projects/debian/images/.gitkeep
+++ b/projects/debian/images/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep


### PR DESCRIPTION
A first attempt at creating a Debian base image for future build stuff.  @indigo423 is this the right way to go about it?  I'm kind of cargo culting it here.

As far as I can tell, this will create an `opennms/debian` image with version `jessie-b<circle-build>` when it becomes a real merge, right?