### PR TITLE
debian build environment images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,18 @@ jobs:
     <<: *common_environment
     working_directory: ~/opennms-container/projects/debian-openjdk
 
+  debian-build-env-jdk8:
+    <<: *common_environment
+    working_directory: ~/opennms-container/projects/debian-build-env-jdk8
+
+  debian-build-env-jdk11:
+    <<: *common_environment
+    working_directory: ~/opennms-container/projects/debian-build-env-jdk11
+
+  debian-build-env-jdk:
+    <<: *common_environment
+    working_directory: ~/opennms-container/projects/debian-build-env-jdk
+
 workflows:
   version: 2
   container_build:
@@ -231,3 +243,15 @@ workflows:
           requires:
             - shellcheck
             - debian
+      - debian-build-env-jdk8:
+          requires:
+            - shellcheck
+            - debian-openjdk-8
+      - debian-build-env-jdk11:
+          requires:
+            - shellcheck
+            - debian-openjdk-11
+      - debian-build-env-jdk:
+          requires:
+            - shellcheck
+            - debian-openjdk

--- a/projects/debian-build-env-jdk/.dockerignore
+++ b/projects/debian-build-env-jdk/.dockerignore
@@ -1,0 +1,10 @@
+.circleci
+.git
+.idea
+images
+*.md
+*.adoc
+*.env
+*.iml
+.gitignore
+LICENSE

--- a/projects/debian-build-env-jdk/Dockerfile
+++ b/projects/debian-build-env-jdk/Dockerfile
@@ -1,0 +1,50 @@
+ARG BASE_IMAGE="openjdk"
+ARG BASE_IMAGE_VERSION="debian-jdk8-jdk11-openj9"
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
+
+SHELL ["/bin/bash", "-c"]
+
+ARG REPO_HOST="debian.opennms.org"
+ARG REPO_RELEASE="stable"
+ARG REPO_KEY_URL="https://${REPO_HOST}/OPENNMS-GPG-KEY"
+
+RUN wget -qO- ${REPO_KEY_URL} | apt-key add - && \
+    echo "deb https://${REPO_HOST} ${REPO_RELEASE} main" > /etc/apt/sources.list.d/opennms.list && \
+    wget -qO- https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
+ARG PACKAGES="autoconf automake build-essential cmake curl debhelper devscripts dh-systemd docker-ce dpkg-sig expect git librrd-dev libtool make nsis po-debconf python python3 rsync shellcheck ssh thin-provisioning-tools"
+
+COPY ./debs /tmp/debs
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install ${PACKAGES} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$(ls -1 /tmp/debs/*.deb 2>/dev/null | wc -l)" != 0 ]; then dpkg -i /tmp/debs/*.deb; fi && \
+    rm -rf /tmp/debs
+
+ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG VERSION
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG BUILD_BRANCH
+
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="OpenNMS Build Environment ${VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"

--- a/projects/debian-build-env-jdk/build_container_image.sh
+++ b/projects/debian-build-env-jdk/build_container_image.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+set -x
+
+# shellcheck source=projects/debian-build-env-jdk/config.sh
+source ./config.sh
+
+# shellcheck source=projects/registry-config.sh
+source ../registry-config.sh
+
+docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg BUILD_DATE="${BUILD_DATE}" \
+  --build-arg VERSION="${VERSION}" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
+  --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
+  --build-arg SHELLCHECK_VERSION="${SHELLCHECK_VERSION}" \
+  --build-arg PACKAGES="${PACKAGES}" \
+  --build-arg REPO_RELEASE="bleeding" \
+  --build-arg REPO_HOST="${REPO_HOST}" \
+  --build-arg REPO_KEY_URL="${REPO_KEY_URL}" \
+  --build-arg VM_TYPE="${VM_TYPE}" \
+  .
+
+docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/debian-build-env-jdk/config.sh
+++ b/projects/debian-build-env-jdk/config.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC2034
+
+# Overwrite project name on DockerHub
+CONTAINER_PROJECT="build-env"
+
+# Base Image Dependency
+BASE_IMAGE="opennms/openjdk"
+BASE_IMAGE_VERSION="debian-jdk8-jdk11-openj9-b3481"
+BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
+SHELLCHECK_VERSION="0.6.0"
+
+# Version information
+VERSION="debian-jdk8-jdk11"
+IMAGE_VERSION=("${VERSION}")
+
+# Most specific tag when it is not build locally and in CircleCI
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${VERSION}-b${CIRCLE_BUILD_NUM}")
+fi
+
+REPO_RELEASE="stable"
+REPO_HOST="debian.opennms.org"
+REPO_KEY_URL="https://${REPO_HOST}/OPENNMS-GPG-KEY"
+
+PACKAGES="autoconf automake build-essential cmake curl debhelper devscripts dh-systemd docker-ce dpkg-sig expect git librrd-dev libtool make nsis po-debconf python python3 rsync shellcheck ssh thin-provisioning-tools"

--- a/projects/debian-build-env-jdk/debs/.gitkeep
+++ b/projects/debian-build-env-jdk/debs/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep

--- a/projects/debian-build-env-jdk/images/.gitkeep
+++ b/projects/debian-build-env-jdk/images/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep

--- a/projects/debian-build-env-jdk11/.dockerignore
+++ b/projects/debian-build-env-jdk11/.dockerignore
@@ -1,0 +1,10 @@
+.circleci
+.git
+.idea
+images
+*.md
+*.adoc
+*.env
+*.iml
+.gitignore
+LICENSE

--- a/projects/debian-build-env-jdk11/Dockerfile
+++ b/projects/debian-build-env-jdk11/Dockerfile
@@ -1,0 +1,50 @@
+ARG BASE_IMAGE="openjdk"
+ARG BASE_IMAGE_VERSION="debian-jdk11-openj9"
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
+
+SHELL ["/bin/bash", "-c"]
+
+ARG REPO_HOST="debian.opennms.org"
+ARG REPO_RELEASE="stable"
+ARG REPO_KEY_URL="https://${REPO_HOST}/OPENNMS-GPG-KEY"
+
+RUN wget -qO- ${REPO_KEY_URL} | apt-key add - && \
+    echo "deb https://${REPO_HOST} ${REPO_RELEASE} main" > /etc/apt/sources.list.d/opennms.list && \
+    wget -qO- https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
+ARG PACKAGES="autoconf automake build-essential cmake curl debhelper devscripts dh-systemd docker-ce dpkg-sig expect git librrd-dev libtool make nsis po-debconf python python3 rsync shellcheck ssh thin-provisioning-tools"
+
+COPY ./debs /tmp/debs
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install ${PACKAGES} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$(ls -1 /tmp/debs/*.deb 2>/dev/null | wc -l)" != 0 ]; then dpkg -i /tmp/debs/*.deb; fi && \
+    rm -rf /tmp/debs
+
+ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG VERSION
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG BUILD_BRANCH
+
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="OpenNMS Build Environment ${VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"

--- a/projects/debian-build-env-jdk11/build_container_image.sh
+++ b/projects/debian-build-env-jdk11/build_container_image.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+set -x
+
+# shellcheck source=projects/debian-build-env-jdk/config.sh
+source ./config.sh
+
+# shellcheck source=projects/registry-config.sh
+source ../registry-config.sh
+
+docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg BUILD_DATE="${BUILD_DATE}" \
+  --build-arg VERSION="${VERSION}" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
+  --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
+  --build-arg SHELLCHECK_VERSION="${SHELLCHECK_VERSION}" \
+  --build-arg PACKAGES="${PACKAGES}" \
+  --build-arg REPO_RELEASE="bleeding" \
+  --build-arg REPO_HOST="${REPO_HOST}" \
+  --build-arg REPO_KEY_URL="${REPO_KEY_URL}" \
+  .
+
+docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/debian-build-env-jdk11/config.sh
+++ b/projects/debian-build-env-jdk11/config.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC2034
+
+# Overwrite project name on DockerHub
+CONTAINER_PROJECT="build-env"
+
+# Base Image Dependency
+BASE_IMAGE="opennms/openjdk"
+BASE_IMAGE_VERSION="debian-jdk11-openj9-b3480"
+BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
+SHELLCHECK_VERSION="0.6.0"
+
+# Version information
+VERSION="debian-jdk11"
+IMAGE_VERSION=("${VERSION}")
+
+# Most specific tag when it is not build locally and in CircleCI
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${VERSION}-b${CIRCLE_BUILD_NUM}")
+fi
+
+REPO_RELEASE="stable"
+REPO_HOST="debian.opennms.org"
+REPO_KEY_URL="https://${REPO_HOST}/OPENNMS-GPG-KEY"
+
+PACKAGES="autoconf automake build-essential cmake curl debhelper devscripts dh-systemd docker-ce dpkg-sig expect git librrd-dev libtool make nsis po-debconf python python3 rsync shellcheck ssh thin-provisioning-tools"

--- a/projects/debian-build-env-jdk11/debs/.gitkeep
+++ b/projects/debian-build-env-jdk11/debs/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep

--- a/projects/debian-build-env-jdk11/images/.gitkeep
+++ b/projects/debian-build-env-jdk11/images/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep

--- a/projects/debian-build-env-jdk8/.dockerignore
+++ b/projects/debian-build-env-jdk8/.dockerignore
@@ -1,0 +1,10 @@
+.circleci
+.git
+.idea
+images
+*.md
+*.adoc
+*.env
+*.iml
+.gitignore
+LICENSE

--- a/projects/debian-build-env-jdk8/Dockerfile
+++ b/projects/debian-build-env-jdk8/Dockerfile
@@ -1,0 +1,50 @@
+ARG BASE_IMAGE="openjdk"
+ARG BASE_IMAGE_VERSION="debian-jdk8-openj9"
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
+
+SHELL ["/bin/bash", "-c"]
+
+ARG REPO_HOST="debian.opennms.org"
+ARG REPO_RELEASE="stable"
+ARG REPO_KEY_URL="https://${REPO_HOST}/OPENNMS-GPG-KEY"
+
+RUN wget -qO- ${REPO_KEY_URL} | apt-key add - && \
+    echo "deb https://${REPO_HOST} ${REPO_RELEASE} main" > /etc/apt/sources.list.d/opennms.list && \
+    wget -qO- https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
+ARG PACKAGES="autoconf automake build-essential cmake curl debhelper devscripts dh-systemd docker-ce dpkg-sig expect git librrd-dev libtool make nsis po-debconf python python3 rsync shellcheck ssh thin-provisioning-tools"
+
+COPY ./debs /tmp/debs
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install ${PACKAGES} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$(ls -1 /tmp/debs/*.deb 2>/dev/null | wc -l)" != 0 ]; then dpkg -i /tmp/debs/*.deb; fi && \
+    rm -rf /tmp/debs
+
+ARG BUILD_DATE="1970-01-01T00:00:00+0000"
+ARG VERSION
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG BUILD_BRANCH
+
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="OpenNMS Build Environment ${VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"

--- a/projects/debian-build-env-jdk8/build_container_image.sh
+++ b/projects/debian-build-env-jdk8/build_container_image.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+set -x
+
+# shellcheck source=projects/debian-build-env-jdk/config.sh
+source ./config.sh
+
+# shellcheck source=projects/registry-config.sh
+source ../registry-config.sh
+
+docker build -t "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
+  --build-arg BUILD_DATE="${BUILD_DATE}" \
+  --build-arg VERSION="${VERSION}" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
+  --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+  --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
+  --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
+  --build-arg SHELLCHECK_VERSION="${SHELLCHECK_VERSION}" \
+  --build-arg PACKAGES="${PACKAGES}" \
+  --build-arg REPO_RELEASE="bleeding" \
+  --build-arg REPO_HOST="${REPO_HOST}" \
+  --build-arg REPO_KEY_URL="${REPO_KEY_URL}" \
+  .
+
+docker image save "${CONTAINER_PROJECT}:${IMAGE_VERSION[0]}" -o "${CONTAINER_IMAGE}"

--- a/projects/debian-build-env-jdk8/config.sh
+++ b/projects/debian-build-env-jdk8/config.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC2034
+
+# Overwrite project name on DockerHub
+CONTAINER_PROJECT="build-env"
+
+# Base Image Dependency
+BASE_IMAGE="opennms/openjdk"
+BASE_IMAGE_VERSION="debian-jdk8-openj9-b3479"
+BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
+SHELLCHECK_VERSION="0.6.0"
+
+# Version information
+VERSION="debian-jdk8"
+IMAGE_VERSION=("${VERSION}")
+
+# Most specific tag when it is not build locally and in CircleCI
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${VERSION}-b${CIRCLE_BUILD_NUM}")
+fi
+
+REPO_RELEASE="stable"
+REPO_HOST="debian.opennms.org"
+REPO_KEY_URL="https://${REPO_HOST}/OPENNMS-GPG-KEY"
+
+PACKAGES="autoconf automake build-essential cmake curl debhelper devscripts dh-systemd docker-ce dpkg-sig expect git librrd-dev libtool make nsis po-debconf python python3 rsync shellcheck ssh thin-provisioning-tools"

--- a/projects/debian-build-env-jdk8/debs/.gitkeep
+++ b/projects/debian-build-env-jdk8/debs/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep

--- a/projects/debian-build-env-jdk8/images/.gitkeep
+++ b/projects/debian-build-env-jdk8/images/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep


### PR DESCRIPTION
This PR adds build environment images for Debian.  I've confirmed that `./makedebs.sh` works in these images, so once this is merged I can start working on opennms circle bits.