### PR TITLE
Build Antora 3.0.0-rc.2 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ aliases:
     command: docker login -u ${CONTAINER_REGISTRY_LOGIN} -p ${CONTAINER_REGISTRY_PASS}
   - &common_steps
     - checkout: *checkout
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 20.10.11
     - run: apk add --no-cache bash
     - run: *registry_login
     - attach_workspace:

--- a/projects/antora/Dockerfile
+++ b/projects/antora/Dockerfile
@@ -5,9 +5,13 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
 ARG VERSION="latest"
 
-RUN apk --no-cache add bash make git openssh-client && \
-    npm i -g gitlab:antora/xref-validator && \
-    npm i -g antora-site-generator-lunr
+RUN apk --no-cache add bash \
+                       make \
+                       git \
+                       openssh-client && \
+    yarn global add --ignore-optional --silent "https://gitlab.com/antora/xref-validator/-/archive/v1.0.0-alpha.14/xref-validator-v1.0.0-alpha.14.tar.gz" && \
+    yarn global add --ignore-optional --silent "https://gitlab.com/antora/antora-lunr-extension"
+
 
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
 ARG SOURCE

--- a/projects/antora/config.sh
+++ b/projects/antora/config.sh
@@ -4,7 +4,7 @@
 
 # Configure base image dependency
 BASE_IMAGE="antora/antora"
-BASE_IMAGE_VERSION="2.3.4"
+BASE_IMAGE_VERSION="3.0.0-rc.2"
 VERSION=${BASE_IMAGE_VERSION}
 IMAGE_VERSION=("${VERSION}")
 


### PR DESCRIPTION
Using Antora 3.0.0-rc.2 as base image and installing xref validation and Lunr extension as packages. For the reason Antora used yarn to build their image, it was suggested to use yarn instead of npm from the Antora community. I had to bump the Docker environment to a current version, the default version in Circle CI has thrown an unexpected EPERM error for permission issues during the yarn package install. The problem is solved with Docker environments 19+.